### PR TITLE
Introduce opts.exponent

### DIFF
--- a/lib/backoff.js
+++ b/lib/backoff.js
@@ -6,7 +6,7 @@ var util         = require('util');
 function Backoff(fn, callback, opts){
     this.attempts = 0;
     this.delay = (opts && opts.delay) || 100;
-    this.exponent = (opts && opts.delay) || 1.4;
+    this.exponent = (opts && opts.exponent) || 1.4;
     this.maxAttemps = (opts && opts.maxAttemps) || 10;
     this.fn = fn;
     this.cancelled = false;


### PR DESCRIPTION
It seems logical to have opts.exponent and use it instead of opts.delay as 100 is good value for delay but the same value for exponent is questionable.
